### PR TITLE
Handle unsorted first column

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# Tsuna
+# Tsuna Excel Sorting App
+
+This repository contains a small command line utility to load an Excel file and sort its contents by a chosen column. The first column is kept exactly as it originally appeared and does not move with the sorted rows. Sorting by the first column itself is not allowed.
+
+## Requirements
+
+- Python 3.12 or higher
+- `pandas` and `openpyxl` packages
+
+Install the required packages with:
+
+```bash
+pip install pandas openpyxl
+```
+
+## Usage
+
+```bash
+python excel_sort.py path/to/file.xlsx --column COLUMN_NAME --output sorted.xlsx
+```
+
+The script sorts data by `COLUMN_NAME`. Only columns after the first one are reordered; the first column stays in its original order. When saving to an output file, cells that have changed position are highlighted in yellow‑green. If `--output` is omitted, the sorted data will be printed to the console.

--- a/excel_sort.py
+++ b/excel_sort.py
@@ -1,0 +1,62 @@
+import argparse
+import sys
+
+try:
+    from openpyxl import load_workbook
+    from openpyxl.styles import PatternFill
+except ImportError:
+    pass  # openpyxl is optional unless writing to Excel
+
+try:
+    import pandas as pd
+except ImportError as e:
+    sys.exit("pandas library is required. Please install pandas and openpyxl before running this script.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Read an Excel file and sort it by a specific column")
+    parser.add_argument("input", help="Path to the Excel file to read")
+    parser.add_argument("--column", required=True, help="Column name to sort by")
+    parser.add_argument("--output", help="Output Excel file path. If omitted, sorted data is printed")
+    args = parser.parse_args()
+
+    df_original = pd.read_excel(args.input)
+    if args.column not in df_original.columns:
+        sys.exit(f"Column '{args.column}' not found in the spreadsheet")
+    first_col_name = df_original.columns[0]
+    if args.column == first_col_name:
+        sys.exit(
+            "Sorting by the first column is not allowed because the first column must remain unchanged"
+        )
+
+    # Save the first column separately so it stays in its original order
+    first_col = df_original[first_col_name]
+    df_to_sort = df_original.drop(columns=first_col_name)
+
+    # Sort remaining columns by the chosen column
+    df_sorted = df_to_sort.sort_values(by=args.column).reset_index(drop=True)
+
+    # Reattach the untouched first column
+    df_sorted.insert(0, first_col_name, first_col.values)
+
+    if args.output:
+        df_sorted.to_excel(args.output, index=False)
+
+        try:
+            wb = load_workbook(args.output)
+            ws = wb.active
+            fill = PatternFill(start_color="CCFF99", end_color="CCFF99", fill_type="solid")
+            diff = df_sorted.ne(df_original)
+            for i, row in enumerate(diff.itertuples(index=False), start=2):
+                for j, changed in enumerate(row, start=1):
+                    if changed:
+                        ws.cell(row=i, column=j).fill = fill
+            wb.save(args.output)
+        except Exception as e:
+            print(f"Failed to apply cell highlighting: {e}")
+
+        print(f"Sorted data saved to {args.output}")
+    else:
+        print(df_sorted)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- keep the first column fixed when sorting by another column
- update README to clarify that only later columns are reordered

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_688b19b059148326b4e28a42c234a92c