### PR TITLE
Add optional output parameter to grep script

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ cells in columns other than the first that change position after sorting are
 highlighted in yellow–green. If `--output` is omitted, the sorted data will be
 printed to the console.
 
+## Grep network directory
+
+The repository also includes a small utility to search for matching lines in
+text files under a directory (for example, on a network share). Results are
+written to a file, which defaults to `grep_out.txt`.
+
+```bash
+python grep_network.py DIRECTORY PATTERN --output results.txt
+```
+
+

--- a/grep_network.py
+++ b/grep_network.py
@@ -1,0 +1,51 @@
+import argparse
+import os
+import re
+import sys
+
+
+def grep_text_files(directory: str, pattern: str, output: str) -> None:
+    """Write matching lines from all .txt files under ``directory`` to ``output``."""
+    regex = re.compile(pattern)
+    try:
+        with open(output, "w", encoding="utf-8") as out_fh:
+            for root, _, files in os.walk(directory):
+                for filename in files:
+                    if filename.lower().endswith(".txt"):
+                        path = os.path.join(root, filename)
+                        try:
+                            with open(path, "r", encoding="utf-8") as fh:
+                                for line in fh:
+                                    if regex.search(line):
+                                        out_fh.write(line)
+                        except FileNotFoundError:
+                            print(f"File not found: {path}", file=sys.stderr)
+                        except OSError as exc:
+                            print(f"Error reading {path}: {exc}", file=sys.stderr)
+    except OSError as exc:
+        sys.exit(f"Cannot write to {output}: {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Search for lines matching PATTERN in text files under a network directory"
+    )
+    parser.add_argument("directory", help="Path to the directory on the network")
+    parser.add_argument("pattern", help="Regex pattern to search for")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="grep_out.txt",
+        help="File to write matching lines (default: grep_out.txt)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.directory):
+        sys.exit(f"Directory not found: {args.directory}")
+
+    grep_text_files(args.directory, args.pattern, args.output)
+    print(f"Wrote matching lines to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow specifying custom output file in `grep_network.py`
- mention grep utility in README

## Testing
- `python grep_network.py . nonexistentpattern`
- `python grep_network.py . import`


------
https://chatgpt.com/codex/tasks/task_b_688b4ec1e6d88326ba74011f0009d7be