### PR TITLE
Add file logging and matched line prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ cells in columns other than the first that change position after sorting are
 highlighted in yellow–green. If `--output` is omitted, the sorted data will be
 printed to the console.
 
+## Grep network directory
+
+The repository also includes a small utility to search for matching lines in
+text files under a directory (for example, on a network share). Each searched
+file name is written to the output, and matching lines are prefixed with
+`=== matched ===`. The script ignores the output file when searching. Results
+are written to a file, which defaults to `grep_out.txt` but can be changed with
+`--output`.
+
+```bash
+python grep_network.py DIRECTORY PATTERN --output results.txt
+```
+
+

--- a/grep_network.py
+++ b/grep_network.py
@@ -1,0 +1,61 @@
+import argparse
+import os
+import re
+import sys
+
+
+def grep_text_files(directory: str, pattern: str, output: str) -> None:
+    """Write searched file names and matching lines to ``output``.
+
+    Matched lines are prefixed with ``"=== matched ==="``.
+    """
+    regex = re.compile(pattern)
+    try:
+        with open(output, "w", encoding="utf-8") as out_fh:
+            for root, _, files in os.walk(directory):
+                for filename in files:
+                    if filename.lower().endswith(".txt"):
+                        path = os.path.join(root, filename)
+                        # Skip the output file if it appears in the walk
+                        if (
+                            os.path.abspath(path) == os.path.abspath(output)
+                            or filename.lower() == "grep_out.txt"
+                        ):
+                            continue
+                        out_fh.write(f"{path}\n")
+                        try:
+                            with open(path, "r", encoding="utf-8") as fh:
+                                for line in fh:
+                                    if regex.search(line):
+                                        out_fh.write("=== matched === " + line)
+                        except FileNotFoundError:
+                            print(f"File not found: {path}", file=sys.stderr)
+                        except OSError as exc:
+                            print(f"Error reading {path}: {exc}", file=sys.stderr)
+    except OSError as exc:
+        sys.exit(f"Cannot write to {output}: {exc}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Search for lines matching PATTERN in text files under a network directory"
+    )
+    parser.add_argument("directory", help="Path to the directory on the network")
+    parser.add_argument("pattern", help="Regex pattern to search for")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="grep_out.txt",
+        help="File to write matching lines (default: grep_out.txt)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.directory):
+        sys.exit(f"Directory not found: {args.directory}")
+
+    grep_text_files(args.directory, args.pattern, args.output)
+    print(f"Wrote matching lines to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how grep script logs searched file names
- prefix matching lines with "=== matched ===" and skip grep_out.txt

## Testing
- `python grep_network.py . hello`
- `python grep_network.py . hello -o results.txt`


------
https://chatgpt.com/codex/tasks/task_b_688b4ec1e6d88326ba74011f0009d7be