### PR TITLE
Add interactive grep search

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,18 @@ cells in columns other than the first that change position after sorting are
 highlighted in yellow–green. If `--output` is omitted, the sorted data will be
 printed to the console.
 
+## Grep network directory
+
+The repository also includes a small utility to search through all `.txt` files
+in a directory (for example, on a network share). Run the script and you will be
+prompted for the directory to search and the text or regular expression to look
+for. Subdirectories are included automatically. Each matching line is printed to
+the console in the format `path:line_number: line text` so the results are easy
+to read. Text files are opened in UTF‑8 with decoding errors ignored, allowing
+files containing multi-byte characters to be processed.
+
+```bash
+python grep_network.py
+```
+
+

--- a/grep_network.py
+++ b/grep_network.py
@@ -1,0 +1,47 @@
+import os
+import re
+
+
+def search_directory(directory: str, pattern: str) -> list[tuple[str, int, str]]:
+    """Return a list of tuples ``(file_path, line_number, line_text)`` for lines
+    matching ``pattern`` in ``directory`` and all subdirectories."""
+
+    regex = re.compile(pattern)
+    matches: list[tuple[str, int, str]] = []
+
+    for root, _, files in os.walk(directory):
+        for filename in files:
+            if filename.lower().endswith(".txt"):
+                path = os.path.join(root, filename)
+                try:
+                    with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                        for lineno, line in enumerate(fh, start=1):
+                            if regex.search(line):
+                                matches.append((path, lineno, line.rstrip("\n")))
+                except OSError as exc:
+                    print(f"Error reading {path}: {exc}")
+
+    return matches
+
+
+def main() -> None:
+    directory = input("検索するディレクトリを入力してください: ").strip()
+    pattern = input("検索する文字列(正規表現)を入力してください: ").strip()
+
+    if not os.path.isdir(directory):
+        print(f"Directory not found: {directory}")
+        return
+
+    results = search_directory(directory, pattern)
+
+    if not results:
+        print("該当する行は見つかりませんでした。")
+        return
+
+    print("\n=== 検索結果 ===")
+    for path, lineno, text in results:
+        print(f"{path}:{lineno}: {text}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make the grep utility interactive instead of command-line driven
- simplify README instructions for running the grep search

## Testing
- `python -m py_compile grep_network.py`
- `printf ".\nnonexistentpattern\n" | python grep_network.py`
- `printf ".\nhello\n" | python grep_network.py`

------
https://chatgpt.com/codex/tasks/task_b_688b4ec1e6d88326ba74011f0009d7be