### PR TITLE
Improve search escaping and label grep outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,27 @@ cells in columns other than the first that change position after sorting are
 highlighted in yellow–green. If `--output` is omitted, the sorted data will be
 printed to the console.
 
+## Grep network directory
+
+The repository also includes a small utility to search through all `.txt` files
+in a directory (for example, on a network share). Running `python
+grep_network.py` launches a simple GUI where you can select the directory to
+search via a folder selection dialog, enter the search string in an edit box and
+view the results in a list below. Each time you press **検索**, new results are
+appended to the list so previous searches remain visible until you clear them.
+Use the **クリアー** button to remove all output. The input boxes and results
+area grow or shrink when the window is resized. Subdirectories are searched
+automatically and matching results are grouped by file. The interface uses a
+dark theme so all controls and results are shown with light text on a dark
+background. The searched directory
+is shown once at the top, then each file name appears on a line beginning with
+`検索ファイル:` and the matching lines are indented underneath. Special
+characters like `[` are automatically escaped so they can be searched without
+using a backslash. Text files are opened in UTF‑8 with decoding errors ignored,
+allowing files containing multi-byte characters to be processed.
+
+```bash
+python grep_network.py
+```
+
+

--- a/grep_network.py
+++ b/grep_network.py
@@ -1,0 +1,137 @@
+import os
+import re
+import tkinter as tk
+from tkinter import filedialog, messagebox, scrolledtext
+
+
+def search_directory(directory: str, pattern: str) -> list[tuple[str, int, str]]:
+    """Return a list of tuples ``(file_path, line_number, line_text)`` for lines
+    matching ``pattern`` in ``directory`` and all subdirectories."""
+
+    try:
+        regex = re.compile(pattern)
+    except re.error:
+        regex = re.compile(re.escape(pattern))
+    matches: list[tuple[str, int, str]] = []
+
+    for root, _, files in os.walk(directory):
+        for filename in files:
+            if filename.lower().endswith(".txt"):
+                path = os.path.join(root, filename)
+                try:
+                    with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+                        for lineno, line in enumerate(fh, start=1):
+                            if regex.search(line):
+                                matches.append((path, lineno, line.rstrip("\n")))
+                except OSError as exc:
+                    print(f"Error reading {path}: {exc}")
+
+    return matches
+
+
+def browse_directory(var: tk.StringVar) -> None:
+    """Open a directory chooser and set ``var`` to the selected path."""
+
+    path = filedialog.askdirectory()
+    if path:
+        var.set(path)
+
+
+def perform_search(
+    dir_var: tk.StringVar,
+    pattern_var: tk.StringVar,
+    output: scrolledtext.ScrolledText,
+) -> None:
+    """Run the search and append results to ``output``."""
+
+    directory = dir_var.get()
+    pattern = pattern_var.get()
+
+    if not directory:
+        messagebox.showerror("エラー", "検索するディレクトリを指定してください")
+        return
+    if not os.path.isdir(directory):
+        messagebox.showerror("エラー", f"Directory not found: {directory}")
+        return
+
+    results = search_directory(directory, pattern)
+
+    output.insert(tk.END, f"検索ディレクトリ: {directory}\n")
+
+    if not results:
+        output.insert(tk.END, "    該当する行は見つかりませんでした。\n")
+        return
+
+    grouped: dict[str, list[str]] = {}
+    for path, _lineno, text in results:
+        rel = os.path.relpath(path, directory)
+        grouped.setdefault(rel, []).append(text)
+
+    for rel, lines in grouped.items():
+        output.insert(tk.END, f"    検索ファイル: {rel}\n")
+        for line in lines:
+            output.insert(tk.END, f"        {line}\n")
+
+
+def clear_results(output: scrolledtext.ScrolledText) -> None:
+    """Remove all text from ``output``."""
+
+    output.delete("1.0", tk.END)
+
+
+def main() -> None:
+    root = tk.Tk()
+    root.title("Network Grep")
+
+    bg = "#1e1e1e"
+    fg = "#ffffff"
+    entry_bg = "#3c3f41"
+    button_bg = "#3c3f41"
+    text_bg = "#272822"
+
+    root.configure(bg=bg)
+
+    dir_var = tk.StringVar()
+    pattern_var = tk.StringVar()
+
+    frame = tk.Frame(root, padx=10, pady=10, bg=bg)
+    frame.pack(fill=tk.BOTH, expand=True)
+
+    # Make widgets expand when the window is resized
+    frame.columnconfigure(1, weight=1)
+    frame.rowconfigure(2, weight=1)
+
+    tk.Label(frame, text="検索するディレクトリ:", bg=bg, fg=fg).grid(row=0, column=0, sticky=tk.W)
+    dir_entry = tk.Entry(frame, textvariable=dir_var, bg=entry_bg, fg=fg, insertbackground=fg)
+    dir_entry.grid(row=0, column=1, sticky="ew")
+    tk.Button(frame, text="参照", command=lambda: browse_directory(dir_var), bg=button_bg, fg=fg, activebackground="#5a5a5a", activeforeground=fg).grid(row=0, column=2, padx=5)
+
+    tk.Label(frame, text="検索文字列:", bg=bg, fg=fg).grid(row=1, column=0, pady=5, sticky=tk.W)
+    pattern_entry = tk.Entry(frame, textvariable=pattern_var, bg=entry_bg, fg=fg, insertbackground=fg)
+    pattern_entry.grid(row=1, column=1, sticky="ew")
+
+    search_btn = tk.Button(
+        frame,
+        text="検索",
+        command=lambda: perform_search(dir_var, pattern_var, results_box),
+        bg=button_bg,
+        fg=fg,
+        activebackground="#5a5a5a",
+        activeforeground=fg,
+    )
+    search_btn.grid(row=1, column=2, padx=5)
+
+    results_box = scrolledtext.ScrolledText(frame, bg=text_bg, fg=fg, insertbackground=fg)
+    results_box.grid(row=2, column=0, columnspan=3, pady=10, sticky="nsew")
+
+    clear_btn = tk.Button(frame, text="クリアー", command=lambda: clear_results(results_box), bg=button_bg, fg=fg, activebackground="#5a5a5a", activeforeground=fg)
+    clear_btn.grid(row=3, column=1, sticky=tk.W)
+
+    exit_btn = tk.Button(frame, text="終了", command=root.destroy, bg=button_bg, fg=fg, activebackground="#5a5a5a", activeforeground=fg)
+    exit_btn.grid(row=3, column=2, sticky=tk.E)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- escape invalid patterns so searching `[` doesn't require a backslash
- show `検索ファイル:` before each file path in the GUI results
- style the Tkinter interface with a dark theme
- document the dark mode behaviour in the README

## Testing
- `python -m py_compile grep_network.py`
- `python grep_network.py` *(fails: no display name and no $DISPLAY environment variable)*

------
https://chatgpt.com/codex/tasks/task_b_688b4ec1e6d88326ba74011f0009d7be